### PR TITLE
課題6-1. ニュースAPIを利用して、最新のニュースを表示するアプリを作成する

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# *<自動生成ファイルの拡張子> linguist-generated=true
+*.freezed.dart linguist-generated=true
+*.g.dart linguist-generated=true
+*.gen.dart linguist-generated=true
+*.gr.dart linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ linked_*.ds
 unlinked.ds
 unlinked_spec.ds
 
+
 # Android related
 **/android/**/gradle-wrapper.jar
 .gradle/

--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ Put the code in the lib/task1 directory.
 
 > 課題2. テキストフィールドに入力された文字列を表示するシンプルなToDoリストアプリを作成する
 
-Put the code in the lib/task2 directory.
+Put the code in the lib/task2 directory. 
+
+> 課題6-1. ニュースAPIを利用して、最新のニュースを表示するアプリを作成する
+
+Put the code in the lib/task6 directory. 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,7 @@
 # https://pub.dev/packages/pedantic_mono
 include: package:pedantic_mono/analysis_options.yaml
+analyzer:
+  plugins:
+    - custom_lint
+  exclude:
+    - lib/**/*.g.dart

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "com.example.flutter_study"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,17 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_study/task2/task2_app.dart';
+import 'dart:ui';
 
-void main() {
-  runApp(const Task2App());
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_study/task6/task6_app.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  DartPluginRegistrant.ensureInitialized();
+  await dotenv.load();
+  runApp(
+    const ProviderScope(
+      child: Task6App(),
+    ),
+  );
 }

--- a/lib/task6/api/news_api.dart
+++ b/lib/task6/api/news_api.dart
@@ -1,0 +1,37 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_study/task6/entity/news.dart';
+
+class NewsApi {
+  String api = 'https://newsapi.org';
+  final dio = Dio()
+    ..options.headers = {
+      'X-Api-Key': dotenv.env['NEWS_API_KEY'],
+    };
+
+  Future<News> everything(
+    String query,
+    int page,
+    int pageSize,
+  ) async {
+    final response = await dio.get<Map<String, dynamic>>(
+      '$api/v2/everything',
+      queryParameters: {
+        'q': query,
+        'page': page,
+        'pageSize': pageSize,
+      },
+    );
+    return News.fromJson(response.data!);
+  }
+}
+
+enum SearchIn { title, description, content }
+
+enum Language { ar, de, en, es, fr, he, it, nl, no, pt, ru, sv, zh }
+
+enum SortBy {
+  relevancy,
+  popularity,
+  publishedAt,
+}

--- a/lib/task6/article.dart
+++ b/lib/task6/article.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import 'entity/article_info.dart';
+
+// typedef GestureTapCallback = void Function();
+class Article extends StatefulWidget {
+  const Article({super.key, required this.onTap, required this.articlesBean});
+
+  final GestureTapCallback onTap;
+  final ArticleInfo articlesBean;
+
+  @override
+  State<Article> createState() => _ArticleState();
+}
+
+class _ArticleState extends State<Article> {
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: BorderDirectional(
+          bottom:
+              BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+        ),
+      ),
+      child: InkWell(
+        onTap: widget.onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  flex: 6,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        widget.articlesBean.title,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      Text(
+                        widget.articlesBean.author ?? '',
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelSmall
+                            ?.copyWith(color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(
+                  width: 5,
+                ),
+                if (widget.articlesBean.urlToImage != null)
+                  Expanded(
+                    flex: 2,
+                    child: Image.network(
+                      widget.articlesBean.urlToImage ?? '',
+                      fit: BoxFit.fitHeight,
+                    ),
+                  )
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/task6/component/filter_bar.dart
+++ b/lib/task6/component/filter_bar.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class FilterBar extends StatefulWidget {
+  const FilterBar({
+    super.key,
+    required this.searchController,
+    required this.onSearch,
+  });
+
+  final TextEditingController searchController;
+  final VoidCallback onSearch;
+
+  @override
+  State<FilterBar> createState() => _FilterBarState();
+}
+
+class _FilterBarState extends State<FilterBar> {
+  @override
+  Widget build(BuildContext context) {
+    final statusBarHeight = MediaQuery.of(context).padding.top;
+    return Padding(
+      padding: EdgeInsets.only(top: statusBarHeight),
+      child: Padding(
+        padding: const EdgeInsets.all(5),
+        child: TextField(
+          controller: widget.searchController,
+          decoration: InputDecoration(
+            hintText: 'Keyword Search',
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.search),
+              onPressed: widget.onSearch,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/task6/entity/article_info.dart
+++ b/lib/task6/entity/article_info.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_study/task6/entity/source.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'article_info.g.dart';
+
+@JsonSerializable()
+class ArticleInfo {
+  ArticleInfo({
+    this.source,
+    required this.author,
+    required this.title,
+    required this.description,
+    required this.url,
+    required this.urlToImage,
+    required this.publishedAt,
+    required this.content,
+  });
+
+  factory ArticleInfo.fromJson(Map<String, dynamic> json) =>
+      _$ArticleInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ArticleInfoToJson(this);
+
+  final Source? source;
+  final String? author;
+  final String title;
+  final String description;
+  final String url;
+  final String? urlToImage;
+  final String publishedAt;
+  final String content;
+}

--- a/lib/task6/entity/article_info.g.dart
+++ b/lib/task6/entity/article_info.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'article_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ArticleInfo _$ArticleInfoFromJson(Map<String, dynamic> json) => ArticleInfo(
+      source: json['source'] == null
+          ? null
+          : Source.fromJson(json['source'] as Map<String, dynamic>),
+      author: json['author'] as String?,
+      title: json['title'] as String,
+      description: json['description'] as String,
+      url: json['url'] as String,
+      urlToImage: json['urlToImage'] as String?,
+      publishedAt: json['publishedAt'] as String,
+      content: json['content'] as String,
+    );
+
+Map<String, dynamic> _$ArticleInfoToJson(ArticleInfo instance) =>
+    <String, dynamic>{
+      'source': instance.source,
+      'author': instance.author,
+      'title': instance.title,
+      'description': instance.description,
+      'url': instance.url,
+      'urlToImage': instance.urlToImage,
+      'publishedAt': instance.publishedAt,
+      'content': instance.content,
+    };

--- a/lib/task6/entity/news.dart
+++ b/lib/task6/entity/news.dart
@@ -1,0 +1,20 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'article_info.dart';
+
+part 'news.g.dart';
+
+@JsonSerializable()
+class News {
+  News({
+    required this.status,
+    required this.totalResults,
+    required this.articles,
+  });
+
+  factory News.fromJson(Map<String, dynamic> json) => _$NewsFromJson(json);
+
+  final String status;
+  final int totalResults;
+  final List<ArticleInfo> articles;
+}

--- a/lib/task6/entity/news.g.dart
+++ b/lib/task6/entity/news.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'news.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+News _$NewsFromJson(Map<String, dynamic> json) => News(
+      status: json['status'] as String,
+      totalResults: json['totalResults'] as int,
+      articles: (json['articles'] as List<dynamic>)
+          .map((e) => ArticleInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$NewsToJson(News instance) => <String, dynamic>{
+      'status': instance.status,
+      'totalResults': instance.totalResults,
+      'articles': instance.articles,
+    };

--- a/lib/task6/entity/source.dart
+++ b/lib/task6/entity/source.dart
@@ -1,0 +1,15 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'source.g.dart';
+
+@JsonSerializable()
+class Source {
+  Source({required this.id, required this.name});
+
+  factory Source.fromJson(Map<String, dynamic> json) => _$SourceFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SourceToJson(this);
+
+  late String? id;
+  late String name;
+}

--- a/lib/task6/entity/source.g.dart
+++ b/lib/task6/entity/source.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'source.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Source _$SourceFromJson(Map<String, dynamic> json) => Source(
+      id: json['id'] as String?,
+      name: json['name'] as String,
+    );
+
+Map<String, dynamic> _$SourceToJson(Source instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/lib/task6/favorite_articles.dart
+++ b/lib/task6/favorite_articles.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:flutter_study/task6/entity/article_info.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'favorite_articles.g.dart';
+
+const _key = 'favorite';
+
+@riverpod
+Future<SharedPreferences> getSharedPreferences(
+  GetSharedPreferencesRef ref,
+) async {
+  return SharedPreferences.getInstance();
+}
+
+@riverpod
+class FavoriteArticles extends _$FavoriteArticles {
+  @override
+  List<ArticleInfo> build() {
+    final prefs = ref.watch(getSharedPreferencesProvider);
+    final list = prefs.value
+            ?.getStringList(_key)
+            ?.map(
+              (e) =>
+                  ArticleInfo.fromJson(json.decode(e) as Map<String, dynamic>),
+            )
+            .toList() ??
+        [];
+    return list;
+  }
+
+  Future<void> _storeArticleList(List<ArticleInfo> list) async {
+    final value = list.map((e) => json.encode(e.toJson())).toList();
+    final isSuccess = await ref
+        .watch(getSharedPreferencesProvider)
+        .value
+        ?.setStringList(_key, value);
+    if (isSuccess != null && isSuccess) {
+      state = list;
+    }
+  }
+
+  Future<void> addItem(ArticleInfo article) async {
+    if (!state.any((element) => element.url == article.url)) {
+      final newList = [...state, article];
+      await _storeArticleList(newList);
+    }
+  }
+
+  Future<void> removeItem(ArticleInfo article) async {
+    final newList = [
+      for (final t in state)
+        if (t.url != article.url) t
+    ];
+    await _storeArticleList(newList);
+  }
+}

--- a/lib/task6/favorite_articles.g.dart
+++ b/lib/task6/favorite_articles.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'favorite_articles.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$getSharedPreferencesHash() =>
+    r'befc7142223700c3bd24912abdda106644b2ea63';
+
+/// See also [getSharedPreferences].
+@ProviderFor(getSharedPreferences)
+final getSharedPreferencesProvider =
+    AutoDisposeFutureProvider<SharedPreferences>.internal(
+  getSharedPreferences,
+  name: r'getSharedPreferencesProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$getSharedPreferencesHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef GetSharedPreferencesRef
+    = AutoDisposeFutureProviderRef<SharedPreferences>;
+String _$favoriteArticlesHash() => r'a2c848b6873509a7ac33fed7a6808932ff30ec4a';
+
+/// See also [FavoriteArticles].
+@ProviderFor(FavoriteArticles)
+final favoriteArticlesProvider =
+    AutoDisposeNotifierProvider<FavoriteArticles, List<ArticleInfo>>.internal(
+  FavoriteArticles.new,
+  name: r'favoriteArticlesProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$favoriteArticlesHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$FavoriteArticles = AutoDisposeNotifier<List<ArticleInfo>>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/lib/task6/favorites_screen.dart
+++ b/lib/task6/favorites_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_study/task6/article.dart';
+
+import 'entity/article_info.dart';
+import 'favorite_articles.dart';
+import 'news_detail_screen.dart';
+
+class FavoritesScreen extends ConsumerStatefulWidget {
+  const FavoritesScreen({super.key});
+
+  @override
+  ConsumerState<FavoritesScreen> createState() => _FavoritesScreenState();
+}
+
+class _FavoritesScreenState extends ConsumerState<FavoritesScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final articles = ref.watch(favoriteArticlesProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Favorite'),
+      ),
+      body: ListView.builder(
+        itemCount: articles.length,
+        itemBuilder: (context, index) {
+          final article = articles[index];
+          return Article(
+            onTap: () {
+              _navigationToDetail(article);
+            },
+            articlesBean: article,
+          );
+        },
+      ),
+    );
+  }
+
+  void _navigationToDetail(ArticleInfo article) {
+    Navigator.of(context).push(
+      MaterialPageRoute<NewsDetailScreen>(
+        builder: (context) => NewsDetailScreen(
+          article: article,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/task6/news_detail_screen.dart
+++ b/lib/task6/news_detail_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_study/task6/entity/article_info.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'favorite_articles.dart';
+
+class NewsDetailScreen extends ConsumerStatefulWidget {
+  const NewsDetailScreen({super.key, required this.article});
+
+  final ArticleInfo article;
+
+  @override
+  ConsumerState<NewsDetailScreen> createState() => _NewsDetailScreenState();
+}
+
+class _NewsDetailScreenState extends ConsumerState<NewsDetailScreen> {
+  final _webViewController = WebViewController();
+
+  @override
+  void initState() {
+    _webViewController.loadRequest(Uri.parse(widget.article.url));
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final favoriteArticles = ref.watch(favoriteArticlesProvider);
+    final favoriteArticlesNotifier =
+        ref.read(favoriteArticlesProvider.notifier);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.article.title),
+        actions: [
+          (favoriteArticles.any((element) => element.url == widget.article.url))
+              ? IconButton(
+                  onPressed: () {
+                    favoriteArticlesNotifier.removeItem(widget.article);
+                  },
+                  icon: const Icon(
+                    Icons.favorite,
+                    color: Colors.red,
+                  ),
+                )
+              : IconButton(
+                  onPressed: () {
+                    favoriteArticlesNotifier.addItem(widget.article);
+                  },
+                  icon: const Icon(Icons.favorite),
+                )
+        ],
+      ),
+      body: WebViewWidget(controller: _webViewController),
+    );
+  }
+}

--- a/lib/task6/news_screen.dart
+++ b/lib/task6/news_screen.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_study/task6/api/news_api.dart';
+import 'package:flutter_study/task6/article.dart';
+import 'package:flutter_study/task6/component/filter_bar.dart';
+import 'package:flutter_study/task6/entity/article_info.dart';
+import 'package:flutter_study/task6/news_detail_screen.dart';
+
+class NewsScreen extends StatefulWidget {
+  const NewsScreen({super.key});
+
+  @override
+  State<NewsScreen> createState() => _NewsScreenState();
+}
+
+class _NewsScreenState extends State<NewsScreen> {
+  final NewsApi _newsApi = NewsApi();
+  int _currentPage = 1;
+  bool _isMoreLoading = false;
+  bool _isMaxResult = false;
+  final List<ArticleInfo> _articles = [];
+  final _searchController = TextEditingController();
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    _scrollController.addListener(_scrollListener);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _scrollController
+      ..removeListener(_scrollListener)
+      ..dispose();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        FilterBar(
+          searchController: _searchController,
+          onSearch: _search,
+        ),
+        Expanded(
+          child: _newsListBuild(context),
+        )
+      ],
+    );
+  }
+
+  Widget _newsListBuild(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: _search,
+      child: ListView.builder(
+        padding: EdgeInsets.zero,
+        controller: _scrollController,
+        itemCount: _articles.length + 1,
+        itemBuilder: (context, index) {
+          if (index < _articles.length) {
+            return Article(
+              onTap: () {
+                _navigationToDetail(_articles[index]);
+              },
+              articlesBean: _articles[index],
+            );
+          }
+          if (_isMaxResult) {
+            return const Text('No more articles');
+          }
+          if (_isMoreLoading) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(5),
+                child: CircularProgressIndicator(),
+              ),
+            );
+          }
+          return null;
+        },
+      ),
+    );
+  }
+
+  void _scrollListener() {
+    if (_scrollController.offset >=
+            _scrollController.position.maxScrollExtent &&
+        !_scrollController.position.outOfRange) {
+      // 滚动到列表底部触发加载更多
+      if (!_isMoreLoading) {
+        setState(() {
+          _isMoreLoading = true;
+        });
+        _loadMoreNews();
+      }
+    }
+  }
+
+  Future<void> _loadMoreNews() async {
+    try {
+      final news = await _newsApi.everything(
+        _searchController.text,
+        _currentPage,
+        20,
+      );
+      _currentPage++;
+      setState(() {
+        _articles.addAll(news.articles);
+        _isMoreLoading = false;
+      });
+    } on Exception catch (_) {
+      setState(() {
+        _isMoreLoading = false;
+        _isMaxResult = true;
+      });
+    }
+  }
+
+  Future<void> _search() {
+    setState(() {
+      _currentPage = 1;
+      _articles.clear();
+      _isMoreLoading = true;
+      _isMaxResult = false;
+    });
+    _loadMoreNews();
+    return Future(() => null);
+  }
+
+  void _navigationToDetail(ArticleInfo article) {
+    Navigator.of(context).push(
+      MaterialPageRoute<NewsDetailScreen>(
+        builder: (context) => NewsDetailScreen(
+          article: article,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/task6/task6_app.dart
+++ b/lib/task6/task6_app.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_study/task6/favorites_screen.dart';
+import 'package:flutter_study/task6/news_screen.dart';
+
+class Task6App extends StatefulWidget {
+  const Task6App({super.key});
+
+  @override
+  State<Task6App> createState() => _Task6AppState();
+}
+
+class _Task6AppState extends State<Task6App> {
+  int _currentTab = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      child: MaterialApp(
+        title: 'Task 6: News',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+          useMaterial3: true,
+          primarySwatch: Colors.blue,
+        ),
+        home: Scaffold(
+          bottomNavigationBar: navigationBarBuild(),
+          body: IndexedStack(
+            index: _currentTab,
+            children: const [
+              NewsScreen(),
+              FavoritesScreen(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget navigationBarBuild() {
+    return BottomNavigationBar(
+      currentIndex: _currentTab,
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.newspaper), label: 'News'),
+        BottomNavigationBarItem(icon: Icon(Icons.favorite), label: 'Favorites'),
+      ],
+      onTap: (index) {
+        setState(() {
+          _currentTab = index;
+        });
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,29 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
   cupertino_icons: ^1.0.2
+  dio: ^5.1.2
   flutter:
     sdk: flutter
+  flutter_dotenv: ^5.1.0
+  flutter_riverpod: ^2.3.6
+  json_annotation: ^4.8.1
+  provider: ^6.0.5
+  riverpod_annotation: ^2.1.1
+  riverpod_generator: ^2.2.3
+  shared_preferences: ^2.1.1
+  webview_flutter: ^4.2.2
+
 
 dev_dependencies:
+  build_runner: ^2.4.4
   flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
+  json_serializable: ^6.7.0
   pedantic_mono: any
+  riverpod_lint: ^1.3.2
+
 flutter:
   uses-material-design: true
+  assets:
+    - .env


### PR DESCRIPTION
## 対応するIssue

#9 

## きのう

- リフレッシュインジケータを使用して実現されたプルダウン更新
- キーワード検索
-  記事をクリックすると、対象のウェブページがWebViewで表示され、右上隅でお気に入りを選択できます
- ホームタブの2番目のメニューアイテムにはすべてのお気に入りを表示するオプションがあります

## 画面
<details>
<summary>CLICK HERE</summary>

![image](https://github.com/HanGuowei/FlutterStudy/assets/110440011/57fe6716-883f-44f0-81f7-7c9eb248e09f)
![image](https://github.com/HanGuowei/FlutterStudy/assets/110440011/e8a419ed-4c60-4ec7-b1fc-574732354bcc)
![image](https://github.com/HanGuowei/FlutterStudy/assets/110440011/00666282-c125-4bcf-8213-0739eee07fe9)

</details>
